### PR TITLE
Gateways mit IP und DNS in site.conf

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -54,17 +54,29 @@
 					key = '3a5c08f47bc7f62eff9a1e6ba072d2906f4ce5f628e81861ba93a9cd2a5dc9d9',
 					remotes = {'ipv4 "warpzone.gw.freifunk-muenster.de" port 14242'},
 				},
-				fusselkater = {
+				fusselkater_dns = {
 					key = '071576a93dd3e7dcdd6e566024879dd01a118cddbc4258247dd825ad42351394',
 					remotes = {'ipv6 "fusselkater.gw.freifunk-muenster.de" port 14242', 'ipv4 "fusselkater.gw.freifunk-muenster.de" port 14242'},
 				},
-				commander1024 = {
+				fusselkater_ip = {
+					key = '071576a93dd3e7dcdd6e566024879dd01a118cddbc4258247dd825ad42351394',
+					remotes = {'ipv6 "2a03:4000:6:500e::1" port 14242', 'ipv4 "37.120.168.53" port 14242'},
+				},
+				commander1024_dns = {
 					key = '9bf14cf6faa8bc0bc87e45b109f065339551cf4ab63a668c1a90897f05eceb36',
 					remotes = {'ipv6 "commander1024.gw.freifunk-muenster.de" port 14242', 'ipv4 "commander1024.gw.freifunk-muenster.de" port 14242'},
 				},				
-				fanlin = {
+				commander1024_ip = {
+					key = '9bf14cf6faa8bc0bc87e45b109f065339551cf4ab63a668c1a90897f05eceb36',
+					remotes = {'ipv6 "2a01:4f8:150:8ff8::5" port 14242', 'ipv4 "176.9.88.123" port 14242'},
+				},				
+				fanlin_dns = {
 					key = '346234ecf552727233b406131c214b5b58ceb4b72b9503276aff419a02fc3137',
 					remotes = {'ipv6 "fanlin.gw.freifunk-muenster.de" port 14242', 'ipv4 "fanlin.gw.freifunk-muenster.de" port 14242'},
+				},				
+				fanlin_ip = {
+					key = '346234ecf552727233b406131c214b5b58ceb4b72b9503276aff419a02fc3137',
+					remotes = {'ipv6 "2001:4ba0:ffec:136::2" port 14242', 'ipv4 "189.163.225.52" port 14242'},
 				},				
 			},
 		},


### PR DESCRIPTION
Gateways mit ip und dns eintragen um auch Routern ohne funktionierendes dns eine Verbindung zu ermöglichen. 
