### PR TITLE
NTP entfernt

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -13,7 +13,7 @@
 	timezone = 'CET-1CEST,M3.5.0,M10.5.0/3', -- Europe/Berlin
 	
 	-- network ntp services
-	ntp_servers = { 'ntp.ffms', '0.de.pool.ntp.org', '1.de.pool.ntp.org', '2.de.pool.ntp.org', '3.de.pool.ntp.org' },
+	ntp_servers = { '0.de.pool.ntp.org', '1.de.pool.ntp.org', '2.de.pool.ntp.org', '3.de.pool.ntp.org' },
 	
 	-- regulatory domain of your wifi
 	regdom = 'DE',


### PR DESCRIPTION
Der NTP Server existiert aktuell nicht, der DNS eintrag wurde auch kürzlich gelöscht. Also sollte der Eintrag auch aus der Firmware raus. Referenz: https://forum.freifunk.net/t/ff-munsterland-dns-defekt/2635/5
