### PR TITLE
Autoupdater-Spanne für v2014.4 konfiguriert

### DIFF
--- a/sign.sh
+++ b/sign.sh
@@ -30,9 +30,9 @@ fi
 cd $WORKSPACE/gluon
 
 # Manifeste erstellen 
-make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=experimental 
-make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=beta 
-make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=stable 
+make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=experimental GLUON_PRIORITY=0
+make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=beta GLUON_PRIORITY=1
+make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_BRANCH=stable GLUON_PRIORITY=3
 
 # Manifeste signieren 
 sh contrib/sign.sh $3 images/sysupgrade/experimental.manifest

--- a/site.conf
+++ b/site.conf
@@ -101,7 +101,6 @@
 				mirrors = {
 					'http://firmware.ffms/site-ffms/stable/sysupgrade',
 				},
-				probability = 0.1,
 				good_signatures = 1,
 				pubkeys = {
 					'6c196570ee5f8f4a567d5e2ae9d37c07dc2e40ef737724ae55f424cd079bac07', -- FF-Buildservice
@@ -112,7 +111,6 @@
 				mirrors = {
 					'http://firmware.ffms/site-ffms/beta/sysupgrade',
 				},
-				probability = 0.3,
 				good_signatures = 1,
 				pubkeys = {
 					'6c196570ee5f8f4a567d5e2ae9d37c07dc2e40ef737724ae55f424cd079bac07', -- FF-Buildservice
@@ -123,7 +121,6 @@
 				mirrors = {
 					'http://firmware.ffms/site-ffms/experimental/sysupgrade',
 				},
-				probability = 0.5,
 				good_signatures = 1,
 				pubkeys = {
 					'6c196570ee5f8f4a567d5e2ae9d37c07dc2e40ef737724ae55f424cd079bac07', -- FF-Buildservice

--- a/site.mk
+++ b/site.mk
@@ -24,4 +24,4 @@ GLUON_SITE_PACKAGES := \
 	haveged 
 	 
 
-GLUON_PRIORITY := 3
+GLUON_PRIORITY ?= 3


### PR DESCRIPTION
- Autoupdater: Experimentelle Firmwares werden am selben Tag,
- beta spätestens am nächsten und
- stable innerhalb von 4 Tagen aktualisiert.
