### PR TITLE
spectrum fix

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -20,7 +20,7 @@
 	wifi24 = {
 		ssid = 'Freifunk',
 		channel = 1,
-		htmode = 'HT40+',
+		htmode = 'HT20',
 		mesh_ssid = '02:d1:11:37:fc:38',
 		mesh_bssid = '02:d1:11:37:fc:38',
 		mesh_mcast_rate = 12000,


### PR DESCRIPTION
20Mhz ist in urbanen WLANs der Default, der Standart erlaubt da
nichtmal 40Mhz. Warum wir auf 40Mhz Bandbreite sind ist unklar.
Vermutlich Zufall und  für Münster City ein Bug, Daher: 20Mhz - wie ein
„guter WLAN Bürger“.
