### PR TITLE
Added SN kgbvax2 with dual fastd

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -119,6 +119,20 @@
 							'ipv4 "5.9.86.154" port 14242'
 						},
 					},
+					kgbvax02a  = {
+						key = '6118166973d2026a9264025d1d78062ac0e9b487217ff95e94a98124761fca3a',
+						remotes = {
+							'ipv6 "2a01:4f8:171:8ad::1" port 14242', 
+							'ipv4 "136.243.99.72" port 14242'
+						},
+					},
+					kgbvax02b = {
+						key = 'ada6cc8eaf5d91eaac274ae0a9192d95b131300136778169289e9aa01fa70fa3',
+						remotes = {
+							'ipv6 "2a01:4f8:171:8ad::1" port 14243', 
+							'ipv4 "136.243.99.72" port 14243'
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Hetzner AX10 ODroid XU4, 4+4 Cores (1G Link, 200Mbit/s garantiert)

Getestet mit Selbstbau Firmware.
Pro Core ~60Mbit. Mehr Tests auf beiden fastd erforderlich.
