### PR TITLE
sn-kgvax-1 entfernt

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -105,13 +105,6 @@
 							'ipv4 "176.221.46.161" port 14242'
 						},
 					},
-					sn_kgbvax_1 = {
-						key = 'dcb64cfca60b1dee8a2da75112f454d95a5c8ee42c3b26a85dc710f7690fe29c',
-						remotes = {
-							'ipv6 "2a03:4000:2:c1::1" port 14242', 
-							'ipv4 "46.38.239.30" port 14242'
-						},
-					},
 					sn_descilla_1 = {
 						key = '87006f9bc133bebabe0027e298eb507a8ba119f31f066f2514f8e9b11b81cd30',
 						remotes = {


### PR DESCRIPTION
Verwendeter vServer deutlich zu lahm, lohnte sich für den Preis nicht.
